### PR TITLE
Add CPE510's to Block MTRNord

### DIFF
--- a/static_ips
+++ b/static_ips
@@ -80,6 +80,16 @@ host RPIFrank2{
         fixed-address 10.129.2.27
         option host-name "RPIFrank2"
 }
+host CPE510EKEBERGKRUG{
+        hardware ethernet c4:e9:84:99:a3:22;
+        fixed-address 10.129.2.28
+        option host-name "CPE510EKEBERGKRUG"
+}
+host CPE510Hollmuehle{
+        hardware ethernet c4:e9:84:b0:b2:52;
+        fixed-address 10.129.2.29
+        option host-name "CPE510Hollmuehle"
+}
 #ende Block mtrnord
 #beginn block kevin
 #address 10.129.2.31

--- a/static_ips
+++ b/static_ips
@@ -69,12 +69,7 @@ host raspberrypi {
 
 #ende Block homwer.com
 #beginn Block mtrnord
-
-host RPIMarcel1{
-        hardware ethernet 64:70:02:2f:10:69;
-        fixed-address 10.129.2.26
-        option host-name "RPIMarcel1"
-}
+#address 10.129.2.26
 host RPIFrank2{
         hardware ethernet 80:1f:02:b3:4e:bf;
         fixed-address 10.129.2.27


### PR DESCRIPTION
Hinzufügen der statischen Ip's für die CPE510's der RiFu-Strecke zwischen Hollmühle und Ekebergkrug.